### PR TITLE
Removed exception on defintion factory re-definition

### DIFF
--- a/DependencyInjection/CmfResourceExtension.php
+++ b/DependencyInjection/CmfResourceExtension.php
@@ -95,13 +95,6 @@ class CmfResourceExtension extends Extension
 
     public function addRepositoryFactory($name, RepositoryFactoryInterface $factory)
     {
-        if (isset($this->repositoryFactories[$name])) {
-            throw new \RuntimeException(sprintf(
-                'Repository factory "%s" has already been set.',
-                $name
-            ));
-        }
-
         $this->repositoryFactories[$name] = $factory;
     }
 


### PR DESCRIPTION
In cases where the bundle is rebooted (e.g. during tests / maybe during kernel warmup) the Factories are reregistered whch throws an Exception in the currentl logifc.

I have removed the exception and simply allow the factories to be re-set. The alternative is returning if the bundle is already set but this seems less robust.