### PR TITLE
Added doctirne phpcr odm description enhancer

### DIFF
--- a/Resources/config/description.xml
+++ b/Resources/config/description.xml
@@ -15,6 +15,15 @@
             <tag name="cmf_resource.description.enhancer" alias="sonata_admin" />
         </service>
 
+        <service id="cmf_resource.description.enhancer.doctrine.phpcr_odm" class="Symfony\Cmf\Component\Resource\Description\Enhancer\Doctrine\PhpcrOdm\PhpcrOdmEnhancer" public="false">
+            <argument type="service" id="cmf_resource.description.enhancer.doctrine.phpcr_odm.metadata_factory" />
+            <tag name="cmf_resource.description.enhancer" alias="doctrine_phpcr_odm" />
+        </service>
+
+        <service id="cmf_resource.description.enhancer.doctrine.phpcr_odm.metadata_factory" class="Doctrine\ODM\PHPCR\Mapping\ClassMetadataFactory" public="false">
+            <factory service="doctrine_phpcr.odm.document_manager" method="getMetadataFactory" />
+        </service>
+
         <service id="cmf_resource.description.enhancer.sylius_resource" class="Symfony\Cmf\Component\Resource\Description\Enhancer\Sylius\ResourceEnhancer" public="false">
             <argument type="service" id="sylius.resource_registry" />
             <argument type="service" id="request_stack" />

--- a/Tests/Unit/Registry/RepositoryRegistryTest.php
+++ b/Tests/Unit/Registry/RepositoryRegistryTest.php
@@ -102,11 +102,11 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
             ]
         );
 
-        $this->assertEquals([ 'test', 'tset' ], $registry->names());
+        $this->assertEquals(['test', 'tset'], $registry->names());
     }
 
     /**
-     * It should return all registered repositories
+     * It should return all registered repositories.
      */
     public function testAll()
     {


### PR DESCRIPTION
This PR adds support for the Doctrine PHPCR-ODM enhancer and will also integrate the Sylius / Sonata enhancers in order that they can use the CHILD_TYPES descriptor (if) previously set.