### PR TITLE
Added all and names methods to registry

### DIFF
--- a/Registry/RepositoryRegistry.php
+++ b/Registry/RepositoryRegistry.php
@@ -46,6 +46,27 @@ class RepositoryRegistry implements RepositoryRegistryInterface
     /**
      * {@inheritdoc}
      */
+    public function names()
+    {
+        return array_keys($this->serviceMap);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function all()
+    {
+        $repositories = [];
+        foreach (array_keys($this->serviceMap) as $name) {
+            $repositories[$name] = $this->get($name);
+        }
+
+        return $repositories;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     public function get($repositoryName)
     {
         if (!isset($this->serviceMap[$repositoryName])) {

--- a/Tests/Unit/Registry/RepositoryRegistryTest.php
+++ b/Tests/Unit/Registry/RepositoryRegistryTest.php
@@ -90,6 +90,39 @@ class RepositoryRegistryTest extends \PHPUnit_Framework_TestCase
         $registry->getRepositoryType($repository->reveal());
     }
 
+    /**
+     * It should return the names of registered repositories.
+     */
+    public function testNames()
+    {
+        $registry = $this->createRegistry(
+            [
+                'test' => 'test_repository',
+                'tset' => 'tset_repository',
+            ]
+        );
+
+        $this->assertEquals([ 'test', 'tset' ], $registry->names());
+    }
+
+    /**
+     * It should return all registered repositories
+     */
+    public function testAll()
+    {
+        $registry = $this->createRegistry(
+            [
+                'test' => 'test_repository',
+                'tset' => 'tset_repository',
+            ]
+        );
+
+        $all = $registry->all();
+        $this->assertCount(2, $all);
+        $this->assertInstanceOf(ResourceRepository::class, $all['test']);
+        $this->assertInstanceOf(ResourceRepository::class, $all['tset']);
+    }
+
     private function createRegistry(array $serviceMap)
     {
         $typeMap = [];


### PR DESCRIPTION
Added methods `names` and `all`. Names returns all the repository names, where as `all` returns all registered instances.