### PR TITLE
Fix remaining open issues

### DIFF
--- a/src/CmfResourceBundle.php
+++ b/src/CmfResourceBundle.php
@@ -14,7 +14,7 @@ namespace Symfony\Cmf\Bundle\ResourceBundle;
 use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\FilesystemFactory;
-use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\DoctrinePhpcrFactory;
+use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\PhpcrFactory;
 use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\DoctrinePhpcrOdmFactory;
 use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Compiler\DescriptionEnhancerPass;
 
@@ -24,8 +24,8 @@ class CmfResourceBundle extends Bundle
     {
         $extension = $container->getExtension('cmf_resource');
         //$extension->addRepositoryFactory('filesystem', new FilesystemFactory());
-        $extension->addRepositoryFactory('doctrine_phpcr', new DoctrinePhpcrFactory());
-        $extension->addRepositoryFactory('doctrine_phpcr_odm', new DoctrinePhpcrOdmFactory());
+        $extension->addRepositoryFactory('phpcr/phpcr', new PhpcrFactory());
+        $extension->addRepositoryFactory('doctrine/phpcr-odm', new DoctrinePhpcrOdmFactory());
 
         $container->addCompilerPass(new DescriptionEnhancerPass());
 

--- a/src/DependencyInjection/Repository/Factory/DoctrinePhpcrOdmFactory.php
+++ b/src/DependencyInjection/Repository/Factory/DoctrinePhpcrOdmFactory.php
@@ -34,7 +34,7 @@ class DoctrinePhpcrOdmFactory implements RepositoryFactoryInterface
      */
     public function getName()
     {
-        return 'doctrine_phpcr_odm';
+        return 'doctrine/phpcr-odm';
     }
 
     /**

--- a/src/DependencyInjection/Repository/Factory/FilesystemFactory.php
+++ b/src/DependencyInjection/Repository/Factory/FilesystemFactory.php
@@ -33,7 +33,7 @@ class FilesystemFactory implements RepositoryFactoryInterface
      */
     public function getName()
     {
-        return 'filesystem';
+        return 'puli/filesystem';
     }
 
     /**

--- a/src/DependencyInjection/Repository/Factory/PhpcrFactory.php
+++ b/src/DependencyInjection/Repository/Factory/PhpcrFactory.php
@@ -16,7 +16,7 @@ use Symfony\Component\DependencyInjection\Reference;
 use Symfony\Component\DependencyInjection\Definition;
 use Symfony\Cmf\Component\Resource\Repository\PhpcrRepository;
 
-class DoctrinePhpcrFactory implements RepositoryFactoryInterface
+class PhpcrFactory implements RepositoryFactoryInterface
 {
     /**
      * {@inheritdoc}
@@ -34,7 +34,7 @@ class DoctrinePhpcrFactory implements RepositoryFactoryInterface
      */
     public function getName()
     {
-        return 'doctrine_phpcr';
+        return 'phpcr/phpcr';
     }
 
     /**

--- a/src/Registry/RepositoryRegistry.php
+++ b/src/Registry/RepositoryRegistry.php
@@ -73,7 +73,11 @@ class RepositoryRegistry implements RepositoryRegistryInterface
      */
     public function get($repositoryName = null)
     {
-        if (!isset($this->serviceMap[$repositoryName ?: $defaultRepositoryName])) {
+        if (null === $repositoryName) {
+            $repositoryName = $this->defaultRepositoryName;
+        }
+
+        if (!isset($this->serviceMap[$repositoryName])) {
             throw new \InvalidArgumentException(sprintf(
                 'Repository "%s" has not been registered, available repositories: "%s".',
                 $repositoryName,

--- a/tests/Resources/app/config/resource.yml
+++ b/tests/Resources/app/config/resource.yml
@@ -1,15 +1,15 @@
 cmf_resource:
     repositories:
         test_repository_phpcr_odm:
-            type: doctrine_phpcr_odm
+            type: doctrine/phpcr-odm
             basepath: /test
 
         test_repository_phpcr:
-            type: doctrine_phpcr
+            type: phpcr/phpcr
             basepath: /test
 
         articles:
-            type: doctrine_phpcr_odm
+            type: doctrine/phpcr-odm
             basepath: /cmf/articles
 
 #        my_filesystem:

--- a/tests/Unit/DependencyInjection/Repository/Factory/PhpcrFactoryTest.php
+++ b/tests/Unit/DependencyInjection/Repository/Factory/PhpcrFactoryTest.php
@@ -11,12 +11,12 @@
 
 namespace Symfony\Cmf\Bundle\ResourceBundle\Tests\Unit\DependencyInjection\Repository\Factory;
 
-use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\DoctrinePhpcrFactory;
+use Symfony\Cmf\Bundle\ResourceBundle\DependencyInjection\Repository\Factory\PhpcrFactory;
 use PHPCR\SessionInterface;
 use Symfony\Cmf\Component\Resource\Repository\PhpcrRepository;
 use PHPCR\NodeInterface;
 
-class DoctrinePhpcrFactoryTest extends FactoryTestCase
+class PhpcrFactoryTest extends FactoryTestCase
 {
     private $session;
 
@@ -62,6 +62,6 @@ class DoctrinePhpcrFactoryTest extends FactoryTestCase
 
     protected function getFactory()
     {
-        return new DoctrinePhpcrFactory();
+        return new PhpcrFactory();
     }
 }


### PR DESCRIPTION
/fixes #24 and #19 
/ping @dantleech What do you think about the `phpcr/phpcr` type name for the PHPCR repository? It doesn't really use doctrine, so I thought the `phpcr` vendor prefix made more sense than the `doctrine` prefix.