### PR TITLE
Add symfony-bundle as type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,5 +40,6 @@
         "branch-alias": {
             "dev-master": "1.1-dev"
         }
-    }
+    },
+    "type": "symfony-bundle"
 }


### PR DESCRIPTION
When trying to introduce the reciepe in https://github.com/symfony/recipes-contrib/pull/184 i realized that the type isn't set correctly.